### PR TITLE
CLI wiring

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 SimpleCov.start do
-  minimum_coverage 100
+  # JRuby is making some issues on CI, but it should generally suffice to enforce 100% on MRI regardless
+  minimum_coverage 100 unless RUBY_ENGINE == "jruby"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     bundler-toolbox (0.1.0)
-      dry-cli
+      dry-cli (~> 0.6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     bundler-toolbox (0.1.0)
+      dry-cli
 
 GEM
   remote: https://rubygems.org/
@@ -18,6 +19,7 @@ GEM
     builder (3.2.4)
     childprocess (3.0.0)
     coderay (1.1.2)
+    concurrent-ruby (1.1.6)
     contracts (0.16.0)
     cucumber (3.1.2)
       builder (>= 2.1.2)
@@ -37,6 +39,8 @@ GEM
     cucumber-wire (0.0.1)
     diff-lcs (1.3)
     docile (1.3.2)
+    dry-cli (0.6.0)
+      concurrent-ruby (~> 1.0)
     ffi (1.12.2)
     formatador (0.2.5)
     gherkin (5.1.0)

--- a/bundler-toolbox.gemspec
+++ b/bundler-toolbox.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "dry-cli"
+  spec.add_dependency "dry-cli", "~> 0.6.0"
 
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "rubocop-performance"

--- a/bundler-toolbox.gemspec
+++ b/bundler-toolbox.gemspec
@@ -28,6 +28,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "dry-cli"
+
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "rubocop-performance"
   spec.add_development_dependency "rubocop-rspec"

--- a/exe/rubytoolbox
+++ b/exe/rubytoolbox
@@ -3,4 +3,6 @@
 
 require "bundler/toolbox"
 
-puts "Plain rubytoolbox executable works!"
+Bundler::Toolbox::CLI.with_environment "standalone" do
+  Dry::CLI.new(Bundler::Toolbox::CLI).call
+end

--- a/features/bundler_plugin.feature
+++ b/features/bundler_plugin.feature
@@ -9,5 +9,6 @@ Feature: Bundler Plugin
     And I run `bundle`
     Then the output should contain "Installed plugin bundler-toolbox"
 
-    And I run `bundle toolbox`
-    Then the output should contain "Bundler plugin integration works!"
+    And I run `bundle toolbox version --info`
+    Then the output should contain "bundler-toolbox v"
+    And the output should contain "Execution environment: bundler"

--- a/features/rubygems_plugin.feature
+++ b/features/rubygems_plugin.feature
@@ -6,5 +6,6 @@ Feature: Rubygems Plugin
     When I run `rake install`
     Then the output should match /bundler-toolbox \([^\)]+\) installed/
 
-    And I run `gem toolbox`
-    Then the output should contain "Rubygems plugin integration works!"
+    And I run `gem toolbox version --info`
+    Then the output should contain "bundler-toolbox v"
+    And the output should contain "Execution environment: rubygems"

--- a/features/rubytoolbox_executable.feature
+++ b/features/rubytoolbox_executable.feature
@@ -6,5 +6,6 @@ Feature: rubytoolbox CLI executable
     When I run `rake install`
     Then the output should match /bundler-toolbox \([^\)]+\) installed/
 
-    And I run `rubytoolbox`
-    Then the output should contain "Plain rubytoolbox executable works!"
+    And I run `rubytoolbox version --info`
+    Then the output should contain "bundler-toolbox v"
+    And the output should contain "Execution environment: standalone"

--- a/lib/bundler/toolbox.rb
+++ b/lib/bundler/toolbox.rb
@@ -2,6 +2,7 @@
 
 require "bundler/toolbox/version"
 require "bundler/toolbox/plugins"
+require "bundler/toolbox/cli"
 
 module Bundler
   module Toolbox

--- a/lib/bundler/toolbox/cli.rb
+++ b/lib/bundler/toolbox/cli.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "dry/cli"
+
+module Bundler
+  module Toolbox
+    module CLI
+      extend Dry::CLI::Registry
+
+      class << self
+        def execution_environment
+          case ENV["BUNDLER_TOOLBOX_ENVIRONMENT"]&.strip
+          when "standalone"
+            "standalone"
+          when "bundler"
+            "bundler"
+          when "rubygems"
+            "rubygems"
+          else
+            "unknown"
+          end
+        end
+
+        def with_environment(new_environment)
+          old_environment = ENV["BUNDLER_TOOLBOX_ENVIRONMENT"]
+          ENV["BUNDLER_TOOLBOX_ENVIRONMENT"] = new_environment
+          yield
+        ensure
+          ENV["BUNDLER_TOOLBOX_ENVIRONMENT"] = old_environment
+        end
+      end
+
+      class Version < Dry::CLI::Command
+        desc "Print version"
+
+        option :info, type: :boolean,
+                      default: false,
+                      desc: "Show additional environment information"
+
+        def call(info: false, **)
+          puts "bundler-toolbox v#{Bundler::Toolbox::VERSION}"
+
+          return unless info
+
+          puts
+          puts "Ruby: #{RUBY_DESCRIPTION}"
+          puts "Execution environment: #{Bundler::Toolbox::CLI.execution_environment}"
+        end
+      end
+
+      register "version", Version, aliases: ["v", "-v", "--version"]
+    end
+  end
+end

--- a/lib/bundler/toolbox/cli.rb
+++ b/lib/bundler/toolbox/cli.rb
@@ -7,21 +7,22 @@ module Bundler
     module CLI
       extend Dry::CLI::Registry
 
+      KNOWN_ENVIRONMENTS = %w[standalone bundler rubygems].freeze
+
       class << self
         def execution_environment
-          case ENV["BUNDLER_TOOLBOX_ENVIRONMENT"]&.strip
-          when "standalone"
-            "standalone"
-          when "bundler"
-            "bundler"
-          when "rubygems"
-            "rubygems"
+          if KNOWN_ENVIRONMENTS.include? ENV["BUNDLER_TOOLBOX_ENVIRONMENT"]
+            ENV["BUNDLER_TOOLBOX_ENVIRONMENT"]
           else
             "unknown"
           end
         end
 
         def with_environment(new_environment)
+          unless KNOWN_ENVIRONMENTS.include? new_environment
+            raise ArgumentError, "Unknown environment #{new_environment}! Known: #{KNOWN_ENVIRONMENTS.inspect}"
+          end
+
           old_environment = ENV["BUNDLER_TOOLBOX_ENVIRONMENT"]
           ENV["BUNDLER_TOOLBOX_ENVIRONMENT"] = new_environment
           yield

--- a/lib/bundler/toolbox/plugins/bundler.rb
+++ b/lib/bundler/toolbox/plugins/bundler.rb
@@ -3,8 +3,9 @@
 class Bundler::Toolbox::Plugins::Bundler < Bundler::Plugin::API
   command "toolbox"
 
-  def exec(command, args)
-    puts "Bundler plugin integration works! #{Bundler::Toolbox::VERSION}"
-    puts "You called " + command + " with args: " + args.inspect
+  def exec(_command, args)
+    Bundler::Toolbox::CLI.with_environment "bundler" do
+      Dry::CLI.new(Bundler::Toolbox::CLI).call arguments: args
+    end
   end
 end

--- a/lib/bundler/toolbox/plugins/rubygems.rb
+++ b/lib/bundler/toolbox/plugins/rubygems.rb
@@ -1,11 +1,24 @@
 # frozen_string_literal: true
 
+require "bundler-toolbox"
+
 class Gem::Commands::ToolboxCommand < Gem::Command
   def initialize
     super "toolbox", "Hello World"
   end
 
   def execute
-    puts "Rubygems plugin integration works!"
+    Bundler::Toolbox::CLI.with_environment "rubygems" do
+      Dry::CLI.new(Bundler::Toolbox::CLI).call arguments: @options[:args]
+    end
+  end
+
+  #
+  # We have to override this handler because otherwise rubygem's own
+  # dynamically created option parser will interfere with the actual CLI
+  # options
+  #
+  def handle_options(args)
+    @options[:args] = args
   end
 end

--- a/spec/bundler/toolbox/cli_spec.rb
+++ b/spec/bundler/toolbox/cli_spec.rb
@@ -4,10 +4,12 @@ require "spec_helper"
 
 RSpec.describe Bundler::Toolbox::CLI do
   around do |example|
-    original = ENV["BUNDLER_TOOLBOX_ENVIRONMENT"]
-    example.run
-  ensure
-    ENV["BUNDLER_TOOLBOX_ENVIRONMENT"] = original
+    begin
+      original = ENV["BUNDLER_TOOLBOX_ENVIRONMENT"]
+      example.run
+    ensure
+      ENV["BUNDLER_TOOLBOX_ENVIRONMENT"] = original
+    end
   end
 
   def invoke(*args)

--- a/spec/bundler/toolbox/cli_spec.rb
+++ b/spec/bundler/toolbox/cli_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Bundler::Toolbox::CLI do
+  around do |example|
+    original = ENV["BUNDLER_TOOLBOX_ENVIRONMENT"]
+    example.run
+  ensure
+    ENV["BUNDLER_TOOLBOX_ENVIRONMENT"] = original
+  end
+
+  def invoke(*args)
+    Dry::CLI.new(described_class).call arguments: args
+  end
+
+  describe ".execution_environment" do
+    described_class::KNOWN_ENVIRONMENTS.each do |environment|
+      it "returns #{environment} when BUNDLER_TOOLBOX_ENVIRONMENT is #{environment}" do
+        ENV["BUNDLER_TOOLBOX_ENVIRONMENT"] = environment
+
+        expect(described_class.execution_environment).to be == environment
+      end
+    end
+
+    [nil, "foo", true, 42].each do |environment|
+      it "returns 'unknown' when BUNDLER_TOOLBOX_ENVIRONMENT is #{environment.inspect}" do
+        ENV["BUNDLER_TOOLBOX_ENVIRONMENT"] = environment.to_s
+
+        expect(described_class.execution_environment).to be == "unknown"
+      end
+    end
+  end
+
+  describe ".with_environment" do
+    it "raises ArgumentError when called with unknown env" do
+      expect { described_class.with_environment("wat") }
+        .to raise_error(ArgumentError, /Unknown environment/)
+    end
+
+    it "changes environment to given one for duration of the block" do
+      block_env = nil
+
+      chosen_env = described_class::KNOWN_ENVIRONMENTS.sample
+
+      described_class.with_environment chosen_env do
+        block_env = described_class.execution_environment
+      end
+
+      expect(block_env).to be == chosen_env
+    end
+
+    it "changes environment back to the previous after block has run" do
+      ENV["BUNDLER_TOOLBOX_ENVIRONMENT"] = "bundler"
+
+      described_class.with_environment("rubygems") {}
+
+      expect(described_class.execution_environment).to be == "bundler"
+    end
+  end
+
+  describe "Version Command" do
+    it "prints version" do
+      expect { invoke "version" }
+        .to output(/^bundler-toolbox v#{Bundler::Toolbox::VERSION}/)
+        .to_stdout
+    end
+
+    it "prints ruby runtime context when invoked with --info" do
+      expect { invoke "version", "--info" }
+        .to output(/Ruby: #{Regexp.escape(RUBY_DESCRIPTION)}/).to_stdout
+    end
+
+    it "prints gem execution environment when invoked with --info" do
+      expect { invoke "version", "--info" }
+        .to output(/Execution environment: #{described_class.execution_environment}/).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
Following bundler/gem/standalone executable wiring in #1 this adds wiring for a shared CLI interface using https://github.com/dry-rb/dry-cli/

This still does not add any actual functionality but fills in the boilerplate for following feature additions that should be straight forward to unit test and integrate with all 3 command line usage ways.