### PR TITLE
Add wiring for actual API clients and fixture-driven mock one

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     bundler-toolbox (0.1.0)
       dry-cli (~> 0.6.0)
+      rubytoolbox-api (>= 0.2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -121,6 +122,7 @@ GEM
     rubocop-rspec (1.39.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
+    rubytoolbox-api (0.2.0)
     shellany (0.0.1)
     simplecov (0.18.5)
       docile (~> 1.1)

--- a/bundler-toolbox.gemspec
+++ b/bundler-toolbox.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "dry-cli", "~> 0.6.0"
+  spec.add_dependency "rubytoolbox-api", ">= 0.2.0"
 
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "rubocop-performance"

--- a/fixtures/simplecov.json
+++ b/fixtures/simplecov.json
@@ -1,0 +1,115 @@
+{
+  "permalink": "simplecov",
+  "categories": [
+    {
+      "permalink": "code_coverage",
+      "category_group": {
+        "permalink": "Code_Quality",
+        "description": null,
+        "name": "Code Quality"
+      },
+      "description": "Utilities that report which code is being run. Most commonly this is used as test coverage which reports what parts of your code are not tested, but there are also tools to find dead production code",
+      "name": "Code Coverage",
+      "urls": {
+        "toolbox_url": "https://www.ruby-toolbox.com/categories/code_coverage"
+      }
+    }
+  ],
+  "description": "Code coverage for Ruby with a powerful configuration library and automatic merging of coverage across test suites",
+  "github_repo": {
+    "path": "colszowka/simplecov",
+    "average_recent_committed_at": "2020-03-18T08:53:55.000Z",
+    "description": "Code coverage for Ruby 1.9+ with a powerful configuration library and automatic merging of coverage across test suites",
+    "is_archived": false,
+    "is_fork": false,
+    "is_mirror": false,
+    "issues": {
+      "url": "https://github.com/colszowka/simplecov/issues",
+      "open_count": 52,
+      "closed_count": 418,
+      "total_count": 470,
+      "closure_rate": "88.94"
+    },
+    "license": "mit",
+    "primary_language": "Ruby",
+    "pull_requests": {
+      "url": "https://github.com/colszowka/simplecov/pulls",
+      "open_count": 4,
+      "closed_count": 83,
+      "merged_count": 343,
+      "total_count": 430,
+      "acceptance_rate": "79.77"
+    },
+    "repo_pushed_at": "2020-06-23T18:37:11.000Z",
+    "stats": {
+      "stargazers_count": 4018,
+      "forks_count": 438,
+      "watchers_count": 65
+    },
+    "url": "https://github.com/colszowka/simplecov",
+    "wiki_url": null
+  },
+  "health": {
+    "overall_level": "green",
+    "statuses": [
+      {
+        "key": "rubygem_long_running",
+        "icon": "diamond",
+        "label": "A long-lived project that still receives updates",
+        "level": "green"
+      }
+    ]
+  },
+  "name": "simplecov",
+  "rubygem": {
+    "name": "simplecov",
+    "current_version": "0.18.5",
+    "first_release_on": "2010-08-21",
+    "latest_release_on": "2020-02-25",
+    "licenses": [
+      "MIT"
+    ],
+    "stats": {
+      "downloads": 102243500,
+      "reverse_dependencies_count": 10486,
+      "quarterly_release_counts": {
+        "2010-3": 6,
+        "2010-4": 1,
+        "2011-1": 3,
+        "2011-2": 1,
+        "2011-3": 2,
+        "2011-4": 1,
+        "2012-1": 2,
+        "2012-2": 3,
+        "2012-4": 2,
+        "2013-2": 1,
+        "2013-3": 1,
+        "2013-4": 2,
+        "2014-3": 2,
+        "2015-1": 1,
+        "2015-2": 1,
+        "2015-4": 2,
+        "2016-1": 1,
+        "2016-3": 1,
+        "2017-1": 3,
+        "2017-3": 2,
+        "2018-1": 2,
+        "2019-3": 2,
+        "2020-1": 9
+      },
+      "releases_count": 51
+    },
+    "url": "https://rubygems.org/gems/simplecov"
+  },
+  "score": "12.01",
+  "urls": {
+    "bug_tracker_url": "https://github.com/colszowka/simplecov/issues",
+    "changelog_url": null,
+    "documentation_url": "https://www.rubydoc.info/gems/simplecov/0.18.5",
+    "homepage_url": "https://github.com/colszowka/simplecov",
+    "mailing_list_url": "https://groups.google.com/forum/#!forum/simplecov",
+    "source_code_url": "https://github.com/colszowka/simplecov/tree/v0.18.5",
+    "toolbox_url": "https://www.ruby-toolbox.com/projects/simplecov",
+    "wiki_url": null
+  }
+}

--- a/lib/bundler/toolbox.rb
+++ b/lib/bundler/toolbox.rb
@@ -3,10 +3,49 @@
 require "bundler/toolbox/version"
 require "bundler/toolbox/plugins"
 require "bundler/toolbox/cli"
+require "rubytoolbox/api"
+require "json"
 
 module Bundler
   module Toolbox
     class Error < StandardError; end
-    # Your code goes here...
+
+    class FixtureAdapter
+      attr_accessor :base_path
+      private :base_path=
+
+      def initialize(base_path: File.join(__dir__, "..", "..", "fixtures"))
+        self.base_path = base_path
+      end
+
+      def compare(*projects)
+        projects.map { |project| response_from_fixture(project) }.compact
+      end
+
+      private
+
+      def response_from_fixture(project)
+        data = JSON.parse File.read(File.join(base_path, "#{project}.json"))
+
+        Rubytoolbox::Api::Project.new(data)
+      # The API omits unknown projects from the collection response
+      rescue Errno::ENOENT
+        nil
+      end
+    end
+
+    class << self
+      def compare(*projects, fixtures: false)
+        adapter(fixtures: fixtures).compare(*projects)
+      end
+
+      def adapter(fixtures: false)
+        if fixtures
+          FixtureAdapter.new
+        else
+          Rubytoolbox::Api.new
+        end
+      end
+    end
   end
 end

--- a/lib/bundler/toolbox/cli.rb
+++ b/lib/bundler/toolbox/cli.rb
@@ -25,9 +25,12 @@ module Bundler
 
           old_environment = ENV["BUNDLER_TOOLBOX_ENVIRONMENT"]
           ENV["BUNDLER_TOOLBOX_ENVIRONMENT"] = new_environment
-          yield
-        ensure
-          ENV["BUNDLER_TOOLBOX_ENVIRONMENT"] = old_environment
+
+          begin
+            yield
+          ensure
+            ENV["BUNDLER_TOOLBOX_ENVIRONMENT"] = old_environment
+          end
         end
       end
 

--- a/spec/bundler/toolbox/cli_spec.rb
+++ b/spec/bundler/toolbox/cli_spec.rb
@@ -4,8 +4,8 @@ require "spec_helper"
 
 RSpec.describe Bundler::Toolbox::CLI do
   around do |example|
+    original = ENV["BUNDLER_TOOLBOX_ENVIRONMENT"]
     begin
-      original = ENV["BUNDLER_TOOLBOX_ENVIRONMENT"]
       example.run
     ensure
       ENV["BUNDLER_TOOLBOX_ENVIRONMENT"] = original

--- a/spec/bundler/toolbox_spec.rb
+++ b/spec/bundler/toolbox_spec.rb
@@ -4,4 +4,53 @@ RSpec.describe Bundler::Toolbox do
   it "has a version number" do
     expect(Bundler::Toolbox::VERSION).not_to be nil
   end
+
+  describe Bundler::Toolbox::FixtureAdapter do
+    describe "#compare" do
+      it "returns a project list containing a Rubytoolbox::Api::Project" do
+        expect(described_class.new.compare("simplecov"))
+          .to be_a(Array)
+          .and have_attributes(size: 1)
+          .and include(kind_of(Rubytoolbox::Api::Project))
+      end
+
+      it "returns expected project for known one" do
+        expect(described_class.new.compare("simplecov").first)
+          .to have_attributes(name: "simplecov")
+      end
+
+      it "ignores unknown projects" do
+        expect(described_class.new.compare("foo", "unknown")).to be_a(Array)
+          .and be_empty
+      end
+    end
+  end
+
+  describe ".adapter" do
+    it "returns FixtureAdapter instance when given fixtures: false" do
+      expect(described_class.adapter(fixtures: true)).to be_a described_class::FixtureAdapter
+    end
+
+    it "returns Rubytoolbox::Api instance when given fixtures: true" do
+      expect(described_class.adapter(fixtures: false)).to be_a Rubytoolbox::Api
+    end
+
+    it "returns Rubytoolbox::Api instance when not passing fixtures flag" do
+      expect(described_class.adapter).to be_a Rubytoolbox::Api
+    end
+  end
+
+  describe ".compare" do
+    it "requests compare for given projects for requested adapter instance" do
+      adapter = instance_double described_class::FixtureAdapter
+
+      allow(described_class).to receive(:adapter)
+        .with(fixtures: "the argument")
+        .and_return(adapter)
+
+      expect(adapter).to receive(:compare).with("foo", "bar", "baz")
+
+      described_class.compare "foo", "bar", "baz", fixtures: "the argument"
+    end
+  end
 end


### PR DESCRIPTION
Adds wiring for https://github.com/rubytoolbox/rubytoolbox-api as well as a interface-compatible mock adapter that uses local fixture file for testing.